### PR TITLE
adjust wandb account info, lr scheduler for version issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Spacetimeformer Multivariate Forecasting
 
-This repository contains the code for the paper, "**Long-Range Transformers for Dynamic Spatiotemporal Forecasting**", Grigsby, Wang and Qi, 2021. ([arxiv](https://arxiv.org/abs/2109.12218))
+This repository contains the code for the paper, "**Long-Range Transformers for Dynamic Spatiotemporal Forecasting**", Grigsby, Wang and Qi, 2021. ([arXiv](https://arxiv.org/abs/2109.12218))
 
 ![spatiotemporal_embedding](readme_media/st-graph.png)
 
 Transformers are a high-performance approach to sequence-to-sequence timeseries forecasting. However, stacking multiple sequences into each token only allows the model to learn *temporal* relationships across time. This can ignore important *spatial* relationships between variables. Our model (nickamed "Spacetimeformer") flattens multivariate timeseries into extended sequences where each token represents the value of one variable at a given timestep. Long-Range Transformers can then learn relationships over both time and space. For much more information, please refer to our paper.
-
-### We will be adding additional instructions, example commands and dataset links in the coming days.
 
 ## Installation 
 This repository was written and tested for **python 3.8** and **pytorch 1.9.0**.
@@ -61,7 +59,7 @@ export STF_WANDB_PROJ="your_project_title"
 # optionally: change wandb logging directory (defaults to ./data/STF_LOG_DIR)
 export STF_LOG_DIR="/somewhere/with/more/disk/space"
 ```
-near the top of the `main` method. wandb logging can then be enabled with the `--wandb` flag.
+wandb logging can then be enabled with the `--wandb` flag.
 
 There are two automated figures that can be saved to wandb between epochs. These include the attention diagrams (e.g., Figure 4 of our paper) and prediction plots (e.g., Figure 6 of our paper). Enable attention diagrams with `--attn_plot` and prediction curves with `--plot`.
 
@@ -115,6 +113,16 @@ If you use this model in academic work please feel free to cite our paper
 ```
 
 ![st-embed-fig](readme_media/embed.png)
+
+## Roadmap, V2 Plans
+
+We are working on a second version of the paper, where we plan to focus on adjustments that make it easier to work with real-world datasets:
+- [ ] Missing data in the encoder sequence (instead of only ignoring the loss values in the decoder)
+- [ ] Multivariate datasets with variables sampled at different time intervals
+- [ ] Additional encoder sequence features beyond the target variables
+
+If you have other suggestions, please feel free to file an issue or email the authors!
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ Dataset Names:
 </p>
 
 ### Logging with Weights and Biases
-We used [wandb](https://wandb.ai/home) to track all of results during development, and you can do the same by hardcoding the correct organization/username and project name in the `train.py` file. Comments indicate the location
+We used [wandb](https://wandb.ai/home) to track all of results during development, and you can do the same by providing your username and project as environment variables:
+```bash
+export STF_WANDB_ACCT="your_username"
+export STF_WANDB_PROJ="your_project_title"
+# optionally: change wandb logging directory (defaults to ./data/STF_LOG_DIR)
+export STF_LOG_DIR="/somewhere/with/more/disk/space"
+```
 near the top of the `main` method. wandb logging can then be enabled with the `--wandb` flag.
 
 There are two automated figures that can be saved to wandb between epochs. These include the attention diagrams (e.g., Figure 4 of our paper) and prediction plots (e.g., Figure 6 of our paper). Enable attention diagrams with `--attn_plot` and prediction curves with `--plot`.
@@ -76,7 +82,7 @@ python train.py spacetimeformer metr-la --start_token_len 3 --batch_size 32 \
 --run_name spatiotemporal_metr-la --base_lr 1e-3 --l2_coeff 1e-2 \
 ```
 
-Temporal Attention Ablation with Negative Log Likelihood Loss on NY-TX Weather ("asos") with WandB Loggin and Figures
+Temporal Attention Ablation with Negative Log Likelihood Loss on NY-TX Weather ("asos") with WandB Logging and Figures
 ```bash
 python train.py spacetimeformer asos --context_points 160 --target_points 40 \ 
 --start_token_len 8 --grad_clip_norm 1 --gpus 0 --batch_size 128 \ 

--- a/spacetimeformer/forecaster.py
+++ b/spacetimeformer/forecaster.py
@@ -161,7 +161,7 @@ class Forecaster(pl.LightningModule, ABC):
 
     def _log_stats(self, section, outs):
         for key in outs.keys():
-            self.log(f"{section}/{key}", outs[key].mean(), sync_dist=True)
+            self.log(f"{section}/{key}", outs[key], sync_dist=True)
 
     def training_step_end(self, outs):
         self._log_stats("train", outs)

--- a/spacetimeformer/spacetimeformer_model/spacetimeformer_model.py
+++ b/spacetimeformer/spacetimeformer_model/spacetimeformer_model.py
@@ -213,14 +213,14 @@ class Spacetimeformer_Forecaster(stf.Forecaster):
             init_lr=self.init_lr,
             peak_lr=self.base_lr,
             warmup_steps=self.warmup_steps,
-            patience=3,
+            patience=2,
             factor=self.decay_factor,
         )
         return {
             "optimizer": optimizer,
             "lr_scheduler": {
                 "scheduler": scheduler,
-                "interval": "step",
+                "interval": "epoch",
                 "frequency": 1,
                 "monitor": "val/forecast_loss",
                 "reduce_on_plateau": True,


### PR DESCRIPTION
Our pytorch lightning training loop was written for version 1.3, which has quickly led to some versioning issues with the current v1.5.8 - especially in logging and lr scheduling. This should fix #17 and #21. 

Also makes it easier to customize wandb account information using environment variables instead of directly editing the train script.